### PR TITLE
Fix allow data uri on img

### DIFF
--- a/src/Extension/Image/Sanitizer/ImgSrcSanitizer.php
+++ b/src/Extension/Image/Sanitizer/ImgSrcSanitizer.php
@@ -38,7 +38,7 @@ class ImgSrcSanitizer
 
         if ($this->allowDataUri) {
             $allowedSchemes[] = 'data';
-            $allowedHosts[] = null;
+            $allowedHosts = null;
         }
 
         if (!$sanitized = $this->sanitizeUrl($input, $allowedSchemes, $allowedHosts, $this->forceHttps)) {

--- a/src/Extension/Image/Sanitizer/ImgSrcSanitizer.php
+++ b/src/Extension/Image/Sanitizer/ImgSrcSanitizer.php
@@ -38,7 +38,9 @@ class ImgSrcSanitizer
 
         if ($this->allowDataUri) {
             $allowedSchemes[] = 'data';
-            $allowedHosts = null;
+            if (null !== $allowedHosts) {
+                $allowedHosts[] = null;
+            }
         }
 
         if (!$sanitized = $this->sanitizeUrl($input, $allowedSchemes, $allowedHosts, $this->forceHttps)) {


### PR DESCRIPTION
When allow_data_uri is set to true on img and allowed_hosts is left at the default null like below, allowed_hosts is effectively overwritten by an array containing only null causing all other images to be blocked.

"img"        => [
"allowed_hosts"      => null, // Example: ["trusted1.com", "google.com"]
"allow_data_uri"     => true
]

I propose this small change to only add the null value if allowedHosts is already an array.