### PR TITLE
set fluent the SanitizerBuilder methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": ">=7.1",
         "ext-dom": "*",
+        "ext-intl": "*",
         "masterminds/html5": "^2.4",
         "psr/log": "^1.0",
         "league/uri-parser": "^1.4.1"

--- a/src/SanitizerBuilder.php
+++ b/src/SanitizerBuilder.php
@@ -42,16 +42,22 @@ class SanitizerBuilder implements SanitizerBuilderInterface
     public function registerExtension(ExtensionInterface $extension)
     {
         $this->extensions[$extension->getName()] = $extension;
+
+        return $this;
     }
 
     public function setParser(?ParserInterface $parser)
     {
         $this->parser = $parser;
+
+        return $this;
     }
 
     public function setLogger(?LoggerInterface $logger)
     {
         $this->logger = $logger;
+
+        return $this;
     }
 
     public function build(array $config): SanitizerInterface

--- a/src/SanitizerBuilderInterface.php
+++ b/src/SanitizerBuilderInterface.php
@@ -24,6 +24,8 @@ interface SanitizerBuilderInterface
      * Register an extension to use in the sanitizer being built.
      *
      * @param ExtensionInterface $extension
+     *
+     * @return SanitizerBuilderInterface
      */
     public function registerExtension(ExtensionInterface $extension);
 


### PR DESCRIPTION
I added the possibility to chain the SanitizerBuilder methods like the classical Builder pattern.

This can enhance readability. For example:
```php
public static function sanitize($html)
{
    return (new SanitizerBuilder())
        ->registerExtension(new BasicExtension())
        ->registerExtension(new ListExtension())
        ->registerExtension(new CodeExtension())
        ->registerExtension(new TableExtension())
        ->registerExtension(new IframeExtension())
        ->registerExtension(new DetailsExtension())
        ->registerExtension(new ExtraExtension())
        ->registerExtension(new BpmExtension())
        ->build(self::SANITIZER_CONFIG)
        ->sanitize($html);
}
```

I also added the `ext-intl` in the `composer.json` `require`, the tests failed because I had not this extension.