### PR TITLE
Allow to configure allowed schemes

### DIFF
--- a/src/Extension/Basic/NodeVisitor/ANodeVisitor.php
+++ b/src/Extension/Basic/NodeVisitor/ANodeVisitor.php
@@ -38,6 +38,7 @@ class ANodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInterf
         parent::__construct($config);
 
         $this->sanitizer = new AHrefSanitizer(
+            $this->config['allowed_schemes'],
             $this->config['allowed_hosts'],
             $this->config['allow_mailto'],
             $this->config['force_https']
@@ -57,6 +58,7 @@ class ANodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInterf
     public function getDefaultConfiguration(): array
     {
         return [
+            'allowed_schemes' => ['http', 'https'],
             'allowed_hosts' => null,
             'allow_mailto' => true,
             'force_https' => false,

--- a/src/Extension/Basic/Sanitizer/AHrefSanitizer.php
+++ b/src/Extension/Basic/Sanitizer/AHrefSanitizer.php
@@ -20,12 +20,14 @@ class AHrefSanitizer
 {
     use UrlSanitizerTrait;
 
+    private $allowedSchemes;
     private $allowedHosts;
     private $allowMailTo;
     private $forceHttps;
 
-    public function __construct(?array $allowedHosts, bool $allowMailTo, bool $forceHttps)
+    public function __construct(array $allowedSchemes, ?array $allowedHosts, bool $allowMailTo, bool $forceHttps)
     {
+        $this->allowedSchemes = $allowedSchemes;
         $this->allowedHosts = $allowedHosts;
         $this->allowMailTo = $allowMailTo;
         $this->forceHttps = $forceHttps;
@@ -33,7 +35,7 @@ class AHrefSanitizer
 
     public function sanitize(?string $input): ?string
     {
-        $allowedSchemes = ['http', 'https'];
+        $allowedSchemes = $this->allowedSchemes;
         $allowedHosts = $this->allowedHosts;
 
         if ($this->allowMailTo) {

--- a/src/Extension/Iframe/NodeVisitor/IframeNodeVisitor.php
+++ b/src/Extension/Iframe/NodeVisitor/IframeNodeVisitor.php
@@ -37,7 +37,11 @@ class IframeNodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorI
     {
         parent::__construct($config);
 
-        $this->sanitizer = new IframeSrcSanitizer($this->config['allowed_hosts'], $this->config['force_https']);
+        $this->sanitizer = new IframeSrcSanitizer(
+            $this->config['allowed_schemes'],
+            $this->config['allowed_hosts'],
+            $this->config['force_https']
+        );
     }
 
     protected function getDomNodeName(): string
@@ -58,6 +62,7 @@ class IframeNodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorI
     public function getDefaultConfiguration(): array
     {
         return [
+            'allowed_schemes' => ['http', 'https'],
             'allowed_hosts' => null,
             'force_https' => false,
         ];

--- a/src/Extension/Iframe/Sanitizer/IframeSrcSanitizer.php
+++ b/src/Extension/Iframe/Sanitizer/IframeSrcSanitizer.php
@@ -20,17 +20,19 @@ class IframeSrcSanitizer
 {
     use UrlSanitizerTrait;
 
+    private $allowedSchemes;
     private $allowedHosts;
     private $forceHttps;
 
-    public function __construct(?array $allowedHosts, bool $forceHttps)
+    public function __construct(array $allowedSchemes, ?array $allowedHosts, bool $forceHttps)
     {
+        $this->allowedSchemes = $allowedSchemes;
         $this->allowedHosts = $allowedHosts;
         $this->forceHttps = $forceHttps;
     }
 
     public function sanitize(?string $input): ?string
     {
-        return $this->sanitizeUrl($input, ['http', 'https'], $this->allowedHosts, $this->forceHttps);
+        return $this->sanitizeUrl($input, $this->allowedSchemes, $this->allowedHosts, $this->forceHttps);
     }
 }

--- a/src/Extension/Image/NodeVisitor/ImgNodeVisitor.php
+++ b/src/Extension/Image/NodeVisitor/ImgNodeVisitor.php
@@ -38,6 +38,7 @@ class ImgNodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInte
         parent::__construct($config);
 
         $this->sanitizer = new ImgSrcSanitizer(
+            $this->config['allowed_schemes'],
             $this->config['allowed_hosts'],
             $this->config['allow_data_uri'],
             $this->config['force_https']
@@ -57,6 +58,7 @@ class ImgNodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInte
     public function getDefaultConfiguration(): array
     {
         return [
+            'allowed_schemes' => ['http', 'https'],
             'allowed_hosts' => null,
             'allow_data_uri' => false,
             'force_https' => false,

--- a/src/Extension/Image/Sanitizer/ImgSrcSanitizer.php
+++ b/src/Extension/Image/Sanitizer/ImgSrcSanitizer.php
@@ -20,12 +20,14 @@ class ImgSrcSanitizer
 {
     use UrlSanitizerTrait;
 
+    private $allowedSchemes;
     private $allowedHosts;
     private $allowDataUri;
     private $forceHttps;
 
-    public function __construct(?array $allowedHosts, bool $allowDataUri, bool $forceHttps)
+    public function __construct(array $allowedSchemes, ?array $allowedHosts, bool $allowDataUri, bool $forceHttps)
     {
+        $this->allowedSchemes = $allowedSchemes;
         $this->allowedHosts = $allowedHosts;
         $this->allowDataUri = $allowDataUri;
         $this->forceHttps = $forceHttps;
@@ -33,7 +35,7 @@ class ImgSrcSanitizer
 
     public function sanitize(?string $input): ?string
     {
-        $allowedSchemes = ['http', 'https'];
+        $allowedSchemes = $this->allowedSchemes;
         $allowedHosts = $this->allowedHosts;
 
         if ($this->allowDataUri) {

--- a/tests/Sanitizer/AHrefSanitizerTest.php
+++ b/tests/Sanitizer/AHrefSanitizerTest.php
@@ -20,6 +20,7 @@ class AHrefSanitizerTest extends TestCase
     {
         // Simple cases
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowMailTo' => false,
             'forceHttps' => false,
@@ -28,6 +29,7 @@ class AHrefSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'allowMailTo' => false,
             'forceHttps' => false,
@@ -36,6 +38,7 @@ class AHrefSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'allowMailTo' => false,
             'forceHttps' => false,
@@ -44,6 +47,7 @@ class AHrefSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowMailTo' => false,
             'forceHttps' => false,
@@ -52,6 +56,7 @@ class AHrefSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowMailTo' => true,
             'forceHttps' => false,
@@ -61,6 +66,7 @@ class AHrefSanitizerTest extends TestCase
 
         // Force HTTPS
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'allowMailTo' => false,
             'forceHttps' => true,
@@ -70,6 +76,7 @@ class AHrefSanitizerTest extends TestCase
 
         // Data-URI not allowed
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowMailTo' => true,
             'forceHttps' => false,
@@ -78,6 +85,7 @@ class AHrefSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowMailTo' => true,
             'forceHttps' => true,
@@ -87,6 +95,7 @@ class AHrefSanitizerTest extends TestCase
 
         // MailTo
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowMailTo' => false,
             'forceHttps' => false,
@@ -95,6 +104,7 @@ class AHrefSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowMailTo' => true,
             'forceHttps' => false,
@@ -103,6 +113,7 @@ class AHrefSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'allowMailTo' => true,
             'forceHttps' => false,
@@ -111,6 +122,7 @@ class AHrefSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'allowMailTo' => true,
             'forceHttps' => true,
@@ -119,6 +131,7 @@ class AHrefSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowMailTo' => true,
             'forceHttps' => false,
@@ -127,10 +140,20 @@ class AHrefSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowMailTo' => true,
             'forceHttps' => false,
             'input' => 'mailto:',
+            'output' => null,
+        ];
+
+        yield [
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => null,
+            'allowMailTo' => true,
+            'forceHttps' => false,
+            'input' => 'http://trusted.com/link.php',
             'output' => null,
         ];
     }
@@ -138,8 +161,8 @@ class AHrefSanitizerTest extends TestCase
     /**
      * @dataProvider provideUrls
      */
-    public function testSanitize($allowedHosts, $allowMailTo, $forceHttps, $input, $expected)
+    public function testSanitize($allowedSchemes, $allowedHosts, $allowMailTo, $forceHttps, $input, $expected)
     {
-        $this->assertSame($expected, (new AHrefSanitizer($allowedHosts, $allowMailTo, $forceHttps))->sanitize($input));
+        $this->assertSame($expected, (new AHrefSanitizer($allowedSchemes, $allowedHosts, $allowMailTo, $forceHttps))->sanitize($input));
     }
 }

--- a/tests/Sanitizer/IframeSrcSanitizerTest.php
+++ b/tests/Sanitizer/IframeSrcSanitizerTest.php
@@ -20,6 +20,7 @@ class IframeSrcSanitizerTest extends TestCase
     {
         // Simple cases
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'forceHttps' => false,
             'input' => 'https://trusted.com/iframe.php',
@@ -27,6 +28,7 @@ class IframeSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'input' => 'https://trusted.com/iframe.php',
@@ -34,6 +36,7 @@ class IframeSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'input' => 'https://untrusted.com/iframe.php',
@@ -41,6 +44,7 @@ class IframeSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'forceHttps' => false,
             'input' => '/iframe.php',
@@ -49,6 +53,7 @@ class IframeSrcSanitizerTest extends TestCase
 
         // Force HTTPS
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => true,
             'input' => 'http://trusted.com/iframe.php',
@@ -57,6 +62,7 @@ class IframeSrcSanitizerTest extends TestCase
 
         // Data-URI not allowed
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'forceHttps' => false,
             'input' => 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
@@ -64,9 +70,18 @@ class IframeSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'forceHttps' => true,
             'input' => 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+            'output' => null,
+        ];
+
+        yield [
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => null,
+            'forceHttps' => false,
+            'input' => 'http://trusted.com/iframe.php',
             'output' => null,
         ];
     }
@@ -74,8 +89,8 @@ class IframeSrcSanitizerTest extends TestCase
     /**
      * @dataProvider provideUrls
      */
-    public function testSanitize($allowedHosts, $forceHttps, $input, $expected)
+    public function testSanitize($allowedSchemes, $allowedHosts, $forceHttps, $input, $expected)
     {
-        $this->assertSame($expected, (new IframeSrcSanitizer($allowedHosts, $forceHttps))->sanitize($input));
+        $this->assertSame($expected, (new IframeSrcSanitizer($allowedSchemes, $allowedHosts, $forceHttps))->sanitize($input));
     }
 }

--- a/tests/Sanitizer/ImgSrcSanitizerTest.php
+++ b/tests/Sanitizer/ImgSrcSanitizerTest.php
@@ -20,6 +20,7 @@ class ImgSrcSanitizerTest extends TestCase
     {
         // Simple cases
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowDataUri' => false,
             'forceHttps' => false,
@@ -28,6 +29,7 @@ class ImgSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'allowDataUri' => false,
             'forceHttps' => false,
@@ -36,6 +38,7 @@ class ImgSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'allowDataUri' => false,
             'forceHttps' => false,
@@ -44,6 +47,7 @@ class ImgSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowDataUri' => false,
             'forceHttps' => false,
@@ -52,6 +56,7 @@ class ImgSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowDataUri' => true,
             'forceHttps' => false,
@@ -61,6 +66,7 @@ class ImgSrcSanitizerTest extends TestCase
 
         // Force HTTPS
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'allowDataUri' => false,
             'forceHttps' => true,
@@ -70,6 +76,7 @@ class ImgSrcSanitizerTest extends TestCase
 
         // Data-URI
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowDataUri' => false,
             'forceHttps' => false,
@@ -78,6 +85,7 @@ class ImgSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowDataUri' => true,
             'forceHttps' => false,
@@ -86,6 +94,7 @@ class ImgSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => ['trusted.com'],
             'allowDataUri' => true,
             'forceHttps' => false,
@@ -94,6 +103,7 @@ class ImgSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowDataUri' => true,
             'forceHttps' => false,
@@ -102,6 +112,7 @@ class ImgSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowDataUri' => true,
             'forceHttps' => false,
@@ -110,10 +121,20 @@ class ImgSrcSanitizerTest extends TestCase
         ];
 
         yield [
+            'allowedSchemes' => ['http', 'https'],
             'allowedHosts' => null,
             'allowDataUri' => true,
             'forceHttps' => false,
             'input' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+            'output' => null,
+        ];
+
+        yield [
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => null,
+            'allowDataUri' => false,
+            'forceHttps' => false,
+            'input' => 'http://trusted.com/image.php',
             'output' => null,
         ];
     }
@@ -121,8 +142,8 @@ class ImgSrcSanitizerTest extends TestCase
     /**
      * @dataProvider provideUrls
      */
-    public function testSanitize($allowedHosts, $allowDataUri, $forceHttps, $input, $expected)
+    public function testSanitize($allowedSchemes, $allowedHosts, $allowDataUri, $forceHttps, $input, $expected)
     {
-        $this->assertSame($expected, (new ImgSrcSanitizer($allowedHosts, $allowDataUri, $forceHttps))->sanitize($input));
+        $this->assertSame($expected, (new ImgSrcSanitizer($allowedSchemes, $allowedHosts, $allowDataUri, $forceHttps))->sanitize($input));
     }
 }


### PR DESCRIPTION
I have a use case where I need to remove all http url from a, img, and iframe nodes (and not converting them to https). This will allow me to do it.